### PR TITLE
Fix authors page order

### DIFF
--- a/lib/sanity.ts
+++ b/lib/sanity.ts
@@ -238,7 +238,7 @@ export async function getAllAutores(): Promise<Autor[]> {
         "sitios": sitios[]->title
       }
     `);
-    return autores;
+    return autores.sort((a: any, b: any) => a.name.localeCompare(b.name));
   } catch (error) {
     console.error('Error al obtener autores desde Sanity:', error);
     return [];


### PR DESCRIPTION
## Summary
- sort authors by name when fetching from Sanity

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com)*

------
https://chatgpt.com/codex/tasks/task_e_683f6dcfcbe483218b8fece09a70a684