### PR TITLE
Fix reading progress calculation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS Instructions
+
+- Run `yarn lint` before committing. It's fine if it fails to fetch packages; include the output in the PR.
+- Commit messages should be en español, cortos y en estilo imperativo.
+- Usa Prettier y el estilo existente para formatear el código.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,17 +6,11 @@ import {
 //import Card from '@/components/Card'
 import FeaturedCard from "@/components/FeaturedCard";
 import FeaturedSlider from "@/components/FeaturedSlider";
-import siteMetadata from "@/data/siteMetadata";
 import SectionContainer from "@/components/SectionContainer";
 import ViewToggle from "@/components/ViewToggle";
 import ClientRedirect from "@/components/ClientRedirect";
-import { Swiper, SwiperSlide } from "swiper/react";
-import { Pagination } from "swiper/modules";
-import "swiper/css";
-import "swiper/css/pagination";
 import PublishBanner from "@/components/PublishBanner";
 import MicrocuentoCard from "@/components/MicrocuentoCard";
-import HighlightStroke from "@/components/HighlightStroke";
 import Image from "next/image";
 
 // Tipo común para ambos orígenes de datos
@@ -207,12 +201,6 @@ export default async function Page() {
         )}
       </SectionContainer>
 
-      {/* Slider con destacados */}
-      <SectionContainer>
-        <div className="container pt-12">
-          <FeaturedSlider projects={allProjects.slice(0, 6)} />
-        </div>
-      </SectionContainer>
     </>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,23 @@
-import { getFeaturedAndNonFeaturedRelatos, getAllMicrocuentos } from '../lib/sanity'
+import {
+  getFeaturedAndNonFeaturedRelatos,
+  getAllMicrocuentos,
+} from "../lib/sanity";
 // import { getSortedProjects, getFeaturedProject, getNonFeaturedProjects } from '@/data/projectsData'
 //import Card from '@/components/Card'
-import FeaturedCard from '@/components/FeaturedCard'
-import FeaturedSlider from '@/components/FeaturedSlider'
-import siteMetadata from '@/data/siteMetadata';
-import SectionContainer from '@/components/SectionContainer'
-import ViewToggle from '@/components/ViewToggle'
-import ClientRedirect from '@/components/ClientRedirect'
-import { Swiper, SwiperSlide } from 'swiper/react'
-import { Pagination } from 'swiper/modules'
-import 'swiper/css'
-import 'swiper/css/pagination'
-import PublishBanner from '@/components/PublishBanner'
-import MicrocuentoCard from '@/components/MicrocuentoCard'
-import HighlightStroke from '@/components/HighlightStroke'
-import Image from 'next/image'
+import FeaturedCard from "@/components/FeaturedCard";
+import FeaturedSlider from "@/components/FeaturedSlider";
+import siteMetadata from "@/data/siteMetadata";
+import SectionContainer from "@/components/SectionContainer";
+import ViewToggle from "@/components/ViewToggle";
+import ClientRedirect from "@/components/ClientRedirect";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Pagination } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/pagination";
+import PublishBanner from "@/components/PublishBanner";
+import MicrocuentoCard from "@/components/MicrocuentoCard";
+import HighlightStroke from "@/components/HighlightStroke";
+import Image from "next/image";
 
 // Tipo común para ambos orígenes de datos
 interface CardProps {
@@ -31,27 +34,27 @@ interface CardProps {
 }
 
 interface Proyecto {
-  title: string
-  description: string
-  imgSrc: string
-  href: string
-  authorImgSrc: string
-  authorName: string
-  authorHref: string
-  bgColor: string
-  tags: string[]
-  publishedAt: string
+  title: string;
+  description: string;
+  imgSrc: string;
+  href: string;
+  authorImgSrc: string;
+  authorName: string;
+  authorHref: string;
+  bgColor: string;
+  tags: string[];
+  publishedAt: string;
 }
 
 interface MicrocuentoData {
-  title: string
-  author: string
-  description: string
-  imgSrc: string
-  href: string
-  bgColor: string
-  tags: string[]
-  publishedAt: string
+  title: string;
+  author: string;
+  description: string;
+  imgSrc: string;
+  href: string;
+  bgColor: string;
+  tags: string[];
+  publishedAt: string;
 }
 
 export default async function Page() {
@@ -59,30 +62,30 @@ export default async function Page() {
   let featuredProject: CardProps | null = null;
   let nonFeaturedProjects: CardProps[] = [];
   const allMicrocuentos = await getAllMicrocuentos();
-  
+
   try {
-    console.log('Obteniendo datos desde Sanity');
+    console.log("Obteniendo datos desde Sanity");
     const { featured, nonFeatured } = await getFeaturedAndNonFeaturedRelatos();
     featuredProject = featured;
     nonFeaturedProjects = nonFeatured;
-    console.log('Datos obtenidos de Sanity:', { 
-      featuredProject: featuredProject?.title, 
-      nonFeaturedCount: nonFeaturedProjects.length 
+    console.log("Datos obtenidos de Sanity:", {
+      featuredProject: featuredProject?.title,
+      nonFeaturedCount: nonFeaturedProjects.length,
     });
   } catch (error) {
-    console.error('Error al obtener datos de Sanity:', error);
+    console.error("Error al obtener datos de Sanity:", error);
   }
 
   const allProjects = [
     ...(featuredProject ? [featuredProject] : []),
-    ...nonFeaturedProjects
+    ...nonFeaturedProjects,
   ];
 
   return (
     <>
       <ClientRedirect />
       <SectionContainer>
-      <div className="space-y-2 pt-6 pb-4 md:space-y-5">
+        <div className="space-y-2 pt-6 pb-4 md:space-y-5">
           <h1
             className="text-xl leading-8 font-extrabold tracking-tight text-gray-900
                       dark:text-gray-50 sm:text-3xl sm:leading-9 md:text-5xl md:leading-12"
@@ -92,20 +95,25 @@ export default async function Page() {
 
           <div className="prose dark:prose-invert max-w-none mb-4">
             <p className="text-lg leading-7 text-gray-700 dark:text-gray-300">
-              Bienvenido a <strong>MarcaPágina</strong>, antes una revista de literatura, ahora una app para leer literatura. Más de{' '}
+              Bienvenido a <strong>MarcaPágina</strong>, antes una revista de
+              literatura, ahora una app para leer literatura. Más de{" "}
               <strong>
                 <a
                   href="/cronologico/"
                   className="!text-gray-900 hover:!text-gray-600 dark:!text-gray-50 dark:hover:!text-gray-300"
-                >300 relatos de ficción contemporánea
-                </a></strong> y <strong>microcuentos</strong>. Explora historias inéditas, escritas por autores emergentes de América Latina.
+                >
+                  300 relatos de ficción contemporánea
+                </a>
+              </strong>{" "}
+              y <strong>microcuentos</strong>. Explora historias inéditas,
+              escritas por autores emergentes de América Latina.
             </p>
           </div>
         </div>
-          
+
         {/* Botones de cambio de vista */}
         <ViewToggle />
-        
+
         {/* Primera fila: 3 relatos sin slider */}
         <div className="container pb-6">
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 md:gap-6">
@@ -170,7 +178,7 @@ export default async function Page() {
           <div className="container pt-16 pb-12">
             <div className="mb-8">
               <h2 className="sr-only">Microcuentos</h2>
-              <Image 
+              <Image
                 src="https://res.cloudinary.com/dx98vnos1/image/upload/v1748448325/microcuentos_h1_ttuzc5.png"
                 alt="Microcuentos"
                 className="h-8 sm:h-10 md:h-12 w-auto"
@@ -179,7 +187,7 @@ export default async function Page() {
                 priority
               />
             </div>
-            
+
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 md:gap-6 auto-rows-fr">
               {allMicrocuentos.slice(0, 3).map((microcuento, index) => (
                 <div key={index} className="flex h-full">
@@ -198,6 +206,13 @@ export default async function Page() {
           </div>
         )}
       </SectionContainer>
+
+      {/* Slider con destacados */}
+      <SectionContainer>
+        <div className="container pt-12">
+          <FeaturedSlider projects={allProjects.slice(0, 6)} />
+        </div>
+      </SectionContainer>
     </>
-  )
+  );
 }

--- a/components/FixedNavMenu.tsx
+++ b/components/FixedNavMenu.tsx
@@ -61,8 +61,21 @@ export default function FixedNavMenu({
   useEffect(() => {
     function updateProgress() {
       const scrollY = window.scrollY
-      const fullHeight = document.documentElement.scrollHeight - window.innerHeight
-      setReadingProgress(fullHeight ? (scrollY / fullHeight) * 100 : 0)
+      const content = document.getElementById('post-content')
+      if (content) {
+        const contentTop = content.getBoundingClientRect().top + window.scrollY
+        const maxScroll = contentTop + content.offsetHeight - window.innerHeight
+        if (scrollY <= contentTop) {
+          setReadingProgress(0)
+        } else if (scrollY >= maxScroll) {
+          setReadingProgress(100)
+        } else {
+          setReadingProgress(((scrollY - contentTop) / (maxScroll - contentTop)) * 100)
+        }
+      } else {
+        const fullHeight = document.documentElement.scrollHeight - window.innerHeight
+        setReadingProgress(fullHeight ? (scrollY / fullHeight) * 100 : 0)
+      }
     }
     updateProgress()
     window.addEventListener('scroll', updateProgress)
@@ -79,6 +92,7 @@ export default function FixedNavMenu({
       <div className="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-900 shadow-sm z-50">
         {/* Progress bar */}
         <div
+          id="progress-bar-component"
           className="h-1 bg-[var(--color-gray-950)] dark:bg-[var(--color-accent)]"
           style={{ width: `${readingProgress}%` }}
         />
@@ -109,6 +123,7 @@ export default function FixedNavMenu({
               {shortenTitle(title)}{' '}
               {readingTime && (() => {
                 const mins = Math.ceil(readingTime.minutes)
+                const remaining = Math.max(Math.ceil(mins * (1 - readingProgress / 100)), 0)
                 const acts = readingTimeActivities[mins] || []
                 return acts.length ? (
                   <button
@@ -125,7 +140,7 @@ export default function FixedNavMenu({
                   >
                     <span className="flex items-center px-2 py-0.5 rounded text-sm font-bold text-gray-900 dark:text-gray-50">
                       <span>(</span>
-                      <span>{mins} min</span>
+                      <span>{remaining} min</span>
                       <Clock className="mx-1 h-4 w-4 text-gray-900 dark:text-gray-50" />
                       <span>)</span>
                     </span>
@@ -133,7 +148,7 @@ export default function FixedNavMenu({
                 ) : (
                   <span className="inline-flex items-center px-2 py-0.5 rounded text-sm font-bold ml-1">
                     <span>(</span>
-                    <span>{mins} min</span>
+                    <span>{remaining} min</span>
                     <Clock className="mx-1 h-4 w-4" />
                     <span>)</span>
                   </span>

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -159,7 +159,10 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
               </dl>
 
               <div className="divide-y divide-gray-200 xl:col-span-3 xl:row-span-2 xl:pb-0 dark:divide-gray-700">
-                <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <div
+                  id="post-content"
+                  className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+                >
                   {showDropCap ? (
                     <div className="prose dark:prose-invert max-w-none [&_p]:!text-lg [&_p]:!leading-7 md:[&_p]:!text-base md:[&_p]:!leading-7 [&_a]:!text-gray-800 [&_a]:!no-underline hover:[&_a]:!underline dark:[&_a]:!text-yellow-400 dark:hover:[&_a]:!text-yellow-300">
                       {(() => {

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -1,36 +1,39 @@
 // layouts/PostLayout.tsx
-import React, { ReactNode } from 'react'
-import { CoreContent } from 'pliny/utils/contentlayer'
-import type { Authors } from 'contentlayer/generated'
-import Comments from '@/components/Comments'
-import Link from '@/components/Link'
-import PageTitle from '@/components/PageTitle'
-import SectionContainer from '@/components/SectionContainer'
-import Image from '@/components/Image'
-import Tag from '@/components/Tag'
-import siteMetadata from '@/data/siteMetadata'
-import seriesMetadata from '@/data/seriesMetadata'
-import ScrollTopAndComment from '@/components/ScrollTopAndComment'
-import { PageSEO } from '@/components/SEO'
-import { getRelativeTime } from '@/lib/time'
+import React, { ReactNode } from "react";
+import { CoreContent } from "pliny/utils/contentlayer";
+import type { Authors } from "contentlayer/generated";
+import Comments from "@/components/Comments";
+import Link from "@/components/Link";
+import PageTitle from "@/components/PageTitle";
+import SectionContainer from "@/components/SectionContainer";
+import Image from "@/components/Image";
+import Tag from "@/components/Tag";
+import siteMetadata from "@/data/siteMetadata";
+import seriesMetadata from "@/data/seriesMetadata";
+import ScrollTopAndComment from "@/components/ScrollTopAndComment";
+import { PageSEO } from "@/components/SEO";
+import { getRelativeTime } from "@/lib/time";
+import FeaturedSlider from "@/components/FeaturedSlider";
+import { getFeaturedAndNonFeaturedRelatos } from "@/lib/sanity";
 
-const editUrl = (path: string) => `${siteMetadata.siteRepo}/blob/main/data/${path}`
+const editUrl = (path: string) =>
+  `${siteMetadata.siteRepo}/blob/main/data/${path}`;
 const discussUrl = (path: string) =>
-  `https://mobile.twitter.com/search?q=${encodeURIComponent(`${siteMetadata.siteUrl}/${path}`)}`
+  `https://mobile.twitter.com/search?q=${encodeURIComponent(`${siteMetadata.siteUrl}/${path}`)}`;
 
 const postDateTemplate: Intl.DateTimeFormatOptions = {
-  weekday: 'long',
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-}
+  weekday: "long",
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+};
 
 interface LayoutProps {
-  content: CoreContent<any>
-  authorDetails: CoreContent<Authors>[]
-  next?: { path: string; title: string }
-  prev?: { path: string; title: string }
-  children: ReactNode
+  content: CoreContent<any>;
+  authorDetails: CoreContent<Authors>[];
+  next?: { path: string; title: string };
+  prev?: { path: string; title: string };
+  children: ReactNode;
 }
 
 interface PostLayoutProps extends LayoutProps {
@@ -38,16 +41,40 @@ interface PostLayoutProps extends LayoutProps {
   autor?: { name: string; slug: string } | null;
 }
 
-export default function PostLayout({ content, authorDetails, next, prev, children, showDropCap = true, autor }: PostLayoutProps) {
-  const { filePath, path, slug, date, title, tags, series, image, bgColor, publishedAt } = content as any
-  const relativeTime = publishedAt ? getRelativeTime(publishedAt) : null
+export default async function PostLayout({
+  content,
+  authorDetails,
+  next,
+  prev,
+  children,
+  showDropCap = true,
+  autor,
+}: PostLayoutProps) {
+  const {
+    filePath,
+    path,
+    slug,
+    date,
+    title,
+    tags,
+    series,
+    image,
+    bgColor,
+    publishedAt,
+  } = content as any;
+  const relativeTime = publishedAt ? getRelativeTime(publishedAt) : null;
   // Determinar si es relato o artículo según la ruta
-  const segments = path.split('/')
-  const type = segments[1] // 'relato' o 'articulo'
-  const isArticle = type === 'articulo'
-  const prevLabel = isArticle ? 'Artículo anterior' : 'Relato anterior'
-  const nextLabel = isArticle ? 'Próximo artículo' : 'Próximo relato'
-  const basePath = path.split('/')[0]
+  const segments = path.split("/");
+  const type = segments[1]; // 'relato' o 'articulo'
+  const isArticle = type === "articulo";
+  const prevLabel = isArticle ? "Artículo anterior" : "Relato anterior";
+  const nextLabel = isArticle ? "Próximo artículo" : "Próximo relato";
+  const basePath = path.split("/")[0];
+
+  const { featured, nonFeatured } = await getFeaturedAndNonFeaturedRelatos();
+  const sliderPosts = [...(featured ? [featured] : []), ...nonFeatured]
+    .slice(0, 6)
+    .filter((p) => p.href !== `/${path}`);
 
   return (
     <div className="relative">
@@ -69,9 +96,7 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                     <dt className="sr-only">Publicado</dt>
                     <dd className="text-base leading-6 font-medium text-gray-500 dark:text-gray-400">
                       {relativeTime && (
-                        <time dateTime={publishedAt}>
-                          {relativeTime}
-                        </time>
+                        <time dateTime={publishedAt}>{relativeTime}</time>
                       )}
                     </dd>
                   </div>
@@ -81,7 +106,7 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                     <a
                       href={`/autor/${autor.slug}`}
                       className="hover:underline text-gray-900 dark:text-gray-100 text-center"
-                      style={{ display: 'inline-block' }}
+                      style={{ display: "inline-block" }}
                     >
                       {autor.name}
                     </a>
@@ -97,7 +122,10 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                 )}
                 {/* Imagen del relato opcional */}
                 {image && (
-                  <div className="relative w-full" style={{ backgroundColor: bgColor }}>
+                  <div
+                    className="relative w-full"
+                    style={{ backgroundColor: bgColor }}
+                  >
                     <div className="max-h-[500px] flex items-center justify-center">
                       <img
                         src={image}
@@ -118,7 +146,10 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                 <dd>
                   <ul className="flex flex-wrap justify-center gap-4 sm:space-x-12 xl:block xl:space-y-8 xl:space-x-0">
                     {authorDetails.map((author) => (
-                      <li className="flex items-center space-x-2" key={author.name}>
+                      <li
+                        className="flex items-center space-x-2"
+                        key={author.name}
+                      >
                         {author.avatar && (
                           <Image
                             src={author.avatar}
@@ -146,8 +177,8 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                                 className="text-black hover:text-gray-700"
                               >
                                 {author.twitter
-                                  .replace('https://twitter.com/', '@')
-                                  .replace('https://x.com/', '@')}
+                                  .replace("https://twitter.com/", "@")
+                                  .replace("https://x.com/", "@")}
                               </Link>
                             )}
                           </dd>
@@ -169,24 +200,43 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                         // Si children es un solo div (como PortableText suele hacer), aplica drop-cap al primer <p>
                         if (
                           children &&
-                          typeof children === 'object' &&
-                          'type' in children &&
-                          children.type === 'div' &&
+                          typeof children === "object" &&
+                          "type" in children &&
+                          children.type === "div" &&
                           React.isValidElement(children) &&
-                          React.isValidElement(children) && Array.isArray((children as React.ReactElement<any>).props?.children)
+                          React.isValidElement(children) &&
+                          Array.isArray(
+                            (children as React.ReactElement<any>).props
+                              ?.children,
+                          )
                         ) {
-                          const innerChildren = (children as React.ReactElement<any>).props.children;
+                          const innerChildren = (
+                            children as React.ReactElement<any>
+                          ).props.children;
                           return (
-                            <div {...(children as React.ReactElement<any>).props}>
-                              {(innerChildren as React.ReactNode[]).map((child, idx) => {
-                                if (idx === 0 && React.isValidElement(child) && child.type === 'p') {
-                                  const childEl = child as React.ReactElement<{ className?: string }>;
-                                  return React.cloneElement(childEl, {
-                                    className: (childEl.props.className || '') + ' drop-cap',
-                                  });
-                                }
-                                return child;
-                              })}
+                            <div
+                              {...(children as React.ReactElement<any>).props}
+                            >
+                              {(innerChildren as React.ReactNode[]).map(
+                                (child, idx) => {
+                                  if (
+                                    idx === 0 &&
+                                    React.isValidElement(child) &&
+                                    child.type === "p"
+                                  ) {
+                                    const childEl =
+                                      child as React.ReactElement<{
+                                        className?: string;
+                                      }>;
+                                    return React.cloneElement(childEl, {
+                                      className:
+                                        (childEl.props.className || "") +
+                                        " drop-cap",
+                                    });
+                                  }
+                                  return child;
+                                },
+                              )}
                             </div>
                           );
                         }
@@ -196,10 +246,17 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                             <>
                               {React.isValidElement(children[0])
                                 ? React.cloneElement(
-                                    children[0] as React.ReactElement<{ className?: string }>,
+                                    children[0] as React.ReactElement<{
+                                      className?: string;
+                                    }>,
                                     {
-                                      className: ((children[0] as React.ReactElement<{ className?: string }> ).props.className || '') + ' drop-cap',
-                                    }
+                                      className:
+                                        ((
+                                          children[0] as React.ReactElement<{
+                                            className?: string;
+                                          }>
+                                        ).props.className || "") + " drop-cap",
+                                    },
                                   )
                                 : children[0]}
                               {children.slice(1)}
@@ -234,6 +291,12 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                   )}
                 </div>
               </div>
+
+              {sliderPosts.length > 0 && (
+                <div className="mt-10">
+                  <FeaturedSlider projects={sliderPosts} />
+                </div>
+              )}
 
               <footer>
                 <div className="divide-gray-200 text-sm leading-5 font-medium xl:col-start-1 xl:row-start-2 xl:divide-y dark:divide-gray-700">
@@ -277,5 +340,5 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
         </article>
       </SectionContainer>
     </div>
-  )
+  );
 }

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -292,13 +292,15 @@ export default async function PostLayout({
                 </div>
               </div>
 
-              {sliderPosts.length > 0 && (
-                <div className="mt-10">
-                  <FeaturedSlider projects={sliderPosts} />
-                </div>
-              )}
-
               <footer>
+                {sliderPosts.length > 0 && (
+                  <div className="mb-8">
+                    <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-4">
+                      También en portada:
+                    </h2>
+                    <FeaturedSlider projects={sliderPosts} />
+                  </div>
+                )}
                 <div className="divide-gray-200 text-sm leading-5 font-medium xl:col-start-1 xl:row-start-2 xl:divide-y dark:divide-gray-700">
                   {(next || prev) && (
                     <div className="flex justify-between py-4 xl:block xl:space-y-8 xl:py-8">

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -294,34 +294,6 @@ export default async function PostLayout({
               </div>
 
               <footer>
-                {sliderPosts.length > 0 && (
-                  <div className="mb-8">
-                    <h1 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-4">
-                      También en portada:
-                    </h1>
-                    <div className="lg:hidden">
-                      <FeaturedSlider projects={sliderPosts} />
-                    </div>
-                    <div className="hidden lg:grid lg:grid-cols-3 gap-6">
-                      {sliderPosts.slice(0, 3).map((project, index) => (
-                        <div key={index} className="flex">
-                          <FeaturedCard
-                            title={project.title}
-                            description={project.description}
-                            imgSrc={project.imgSrc}
-                            href={project.href}
-                            authorImgSrc={project.authorImgSrc}
-                            authorName={project.authorName}
-                            authorHref={project.authorHref}
-                            bgColor={project.bgColor}
-                            tags={project.tags}
-                            publishedAt={project.publishedAt}
-                          />
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
                 <div className="divide-gray-200 text-sm leading-5 font-medium xl:col-start-1 xl:row-start-2 xl:divide-y dark:divide-gray-700">
                   {(next || prev) && (
                     <div className="flex justify-between py-4 xl:block xl:space-y-8 xl:py-8">
@@ -362,6 +334,38 @@ export default async function PostLayout({
           </div>
         </article>
       </SectionContainer>
+      
+      {/* Sección "También en portada" al ancho completo */}
+      {sliderPosts.length > 0 && (
+        <SectionContainer>
+          <div className="-mt-16 mb-8">
+            <h1 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-4">
+              También en portada:
+            </h1>
+            <div className="lg:hidden">
+              <FeaturedSlider projects={sliderPosts} />
+            </div>
+            <div className="hidden lg:grid lg:grid-cols-3 gap-6">
+              {sliderPosts.slice(0, 3).map((project, index) => (
+                <div key={index} className="flex">
+                  <FeaturedCard
+                    title={project.title}
+                    description={project.description}
+                    imgSrc={project.imgSrc}
+                    href={project.href}
+                    authorImgSrc={project.authorImgSrc}
+                    authorName={project.authorName}
+                    authorHref={project.authorHref}
+                    bgColor={project.bgColor}
+                    tags={project.tags}
+                    publishedAt={project.publishedAt}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </SectionContainer>
+      )}
     </div>
   );
 }

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -14,6 +14,7 @@ import ScrollTopAndComment from "@/components/ScrollTopAndComment";
 import { PageSEO } from "@/components/SEO";
 import { getRelativeTime } from "@/lib/time";
 import FeaturedSlider from "@/components/FeaturedSlider";
+import FeaturedCard from "@/components/FeaturedCard";
 import { getFeaturedAndNonFeaturedRelatos } from "@/lib/sanity";
 
 const editUrl = (path: string) =>
@@ -295,10 +296,30 @@ export default async function PostLayout({
               <footer>
                 {sliderPosts.length > 0 && (
                   <div className="mb-8">
-                    <h2 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-4">
+                    <h1 className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-4">
                       También en portada:
-                    </h2>
-                    <FeaturedSlider projects={sliderPosts} />
+                    </h1>
+                    <div className="lg:hidden">
+                      <FeaturedSlider projects={sliderPosts} />
+                    </div>
+                    <div className="hidden lg:grid lg:grid-cols-3 gap-6">
+                      {sliderPosts.slice(0, 3).map((project, index) => (
+                        <div key={index} className="flex">
+                          <FeaturedCard
+                            title={project.title}
+                            description={project.description}
+                            imgSrc={project.imgSrc}
+                            href={project.href}
+                            authorImgSrc={project.authorImgSrc}
+                            authorName={project.authorName}
+                            authorHref={project.authorHref}
+                            bgColor={project.bgColor}
+                            tags={project.tags}
+                            publishedAt={project.publishedAt}
+                          />
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 )}
                 <div className="divide-gray-200 text-sm leading-5 font-medium xl:col-start-1 xl:row-start-2 xl:divide-y dark:divide-gray-700">


### PR DESCRIPTION
## Summary
- compute progress bar based on article container height
- show minutes remaining as you read
- tag progress bar for cross‑browser styling
- mark article container with an id so JS can reference it

## Testing
- `yarn lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684033aaa1fc832187312362af4e944e