### PR TITLE
Actualizar colores base y enlaces

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -56,7 +56,7 @@ export default function Home({ posts }) {
                       <div className="text-base leading-6 font-medium">
                         <Link
                           href={`/blog/${slug}`}
-                          className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+                          className="hover:underline"
                           aria-label={`Read more: "${title}"`}
                         >
                           Read more &rarr;
@@ -74,7 +74,7 @@ export default function Home({ posts }) {
         <div className="flex justify-end text-base leading-6 font-medium">
           <Link
             href="/blog"
-            className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+            className="hover:underline"
             aria-label="All posts"
           >
             All Posts &rarr;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -141,9 +141,7 @@ export default function RootLayout({
           href={`${basePath}/feed.xml`}
         />
       </head>
-      <body
-        className="bg-white text-black antialiased dark:bg-gray-950 dark:text-white font-serif"
-      >
+      <body className="antialiased font-serif">
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           <ThemeProviders>
             <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />

--- a/app/publica/PublicaClient.tsx
+++ b/app/publica/PublicaClient.tsx
@@ -398,7 +398,7 @@ export default function PublicaClient() {
             <p>
               1) Te mostraremos un cuento breve al azar para que puedas explorar el tono, la atmósfera y la mirada narrativa que cultivamos en Marcapágina.  
               <HighlightStroke>
-                <a href="/criterios-editoriales" className="font-semibold !text-black hover:text-[var(--color-gray-700)] dark:text-[var(--color-text-dark)] dark:hover:text-[var(--color-accent)]">
+                <a href="/criterios-editoriales" className="font-semibold hover:underline">
                   Ver criterios editoriales
                 </a>
               </HighlightStroke>

--- a/app/relato/[slug]/page.tsx
+++ b/app/relato/[slug]/page.tsx
@@ -245,10 +245,7 @@ export default async function Page(props: {
                       relato.slug === slug ? 'bg-[#faff00]' : 'bg-white'
                     }`}
                   />
-                  <Link
-                    href={`/relato/${relato.slug}`}
-                    className="block hover:text-gray-700 dark:hover:text-gray-300"
-                  >
+                  <Link href={`/relato/${relato.slug}`} className="block hover:underline">
                     <div className="flex items-center">
                       <span className="font-medium text-black dark:text-white">
                         {relato.order}. {relato.title}

--- a/app/transtextos/acerca-de/page.tsx
+++ b/app/transtextos/acerca-de/page.tsx
@@ -43,7 +43,7 @@ export default async function TranstextosAcercaDePage() {
           </h1>
         </div>
 
-        <div className="prose dark:prose-invert max-w-none [&_a]:!text-black dark:[&_a]:text-white [&_a:hover]:!text-gray-600 dark:[&_a:hover]:text-gray-400">
+        <div className="prose dark:prose-invert max-w-none">
           <div className="text-lg leading-7 text-gray-700 dark:text-gray-300 space-y-6">
             <div>
               <p>

--- a/app/transtextos/acerca-de/page.tsx
+++ b/app/transtextos/acerca-de/page.tsx
@@ -47,9 +47,8 @@ export default async function TranstextosAcercaDePage() {
           <div className="text-lg leading-7 text-gray-700 dark:text-gray-300 space-y-6">
             <div>
               <p>
-                <strong>Transtextos</strong> es un archivo literario de relatos, 
-                cuentos breves y textos contemporáneos iniciado por el escritor y 
-                periodista{' '}
+                Transtextos es un archivo literario de relatos, cuentos breves y
+                textos contemporáneos iniciado por el escritor y periodista
                 <a
                   href="https://es.wikipedia.org/wiki/Javier_Miranda_Luque"
                   target="_blank"
@@ -57,13 +56,8 @@ export default async function TranstextosAcercaDePage() {
                 >
                   Javier Miranda-Luque (1959–2023)
                 </a>
-                . Ahora funcionará como subsitio de la aplicación{' '}
-                <a
-                  href="https://www.marcapagina.page"
-                >
-                   MarcaPágina
-                </a>
-                .
+                . Ahora funcionará como subsitio de la aplicación
+                <a href="https://www.marcapagina.page">MarcaPágina</a>.
               </p>
 
               <p>

--- a/components/FeaturedCard.tsx
+++ b/components/FeaturedCard.tsx
@@ -62,7 +62,7 @@ export default function FeaturedCard({
           <div className="flex flex-col mt-auto">
             <div className="px-6 mb-2">
               <h2 className="text-xl font-bold leading-8 tracking-tight">
-                <Link href={href} className="text-gray-900 dark:text-gray-100">
+                <Link href={href} className="hover:underline">
                   {formattedTitle}
                 </Link>
               </h2>

--- a/components/FixedNavMenu.tsx
+++ b/components/FixedNavMenu.tsx
@@ -206,7 +206,7 @@ export default function FixedNavMenu({
                 <>Más relatos de la serie <span className="text-gray-900 dark:text-gray-50">{seriesName}</span></>
               ) : (
                 <>Más {pathPrefix === 'relato' ? 'relatos' : 'artículos'} de{' '}
-                  <Link href={`/autor/${author}`} className="text-gray-500 hover:underline">
+                  <Link href={`/autor/${author}`} className="hover:underline">
                     {authorName}
                   </Link>
                 </>
@@ -218,7 +218,7 @@ export default function FixedNavMenu({
                   <Link
                     href={`/${pathPrefix}/${post.slug}`}
                     onClick={() => setMenuOpen(false)}
-                    className={`block text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:underline ${post.slug === slug ? 'font-semibold' : ''}`}
+                    className={`block hover:underline ${post.slug === slug ? 'font-semibold' : ''}`}
                   >
                     {post.title}{' '}
                     {post.readingTime && `(${Math.ceil(post.readingTime.minutes)} min)`}

--- a/components/PublishBanner.tsx
+++ b/components/PublishBanner.tsx
@@ -26,7 +26,7 @@ export default function PublishBanner() {
         {/* Texto - abajo en móvil, derecha en desktop */}
         <div className="order-2 md:order-2 flex-1 text-left">
           <p className="text-lg mb-2">
-            <strong>¿Te gustaría publicar tu relato en <Link href="https://www.marcapagina.page" className="text-black underline hover:text-gray-700">marcapagina.page</Link>?</strong>
+            <strong>¿Te gustaría publicar tu relato en <Link href="https://www.marcapagina.page" className="underline hover:underline">marcapagina.page</Link>?</strong>
           </p>
           <p className="mb-4">En Marcapágina buscamos nuevas voces y relatos. Si tienes un texto que quieras compartir, ¡anímate a enviarlo!</p>
           <Link

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -50,8 +50,8 @@
   /* Colores de enlaces */
   --color-link-light: var(--color-text-light); /* Enlaces en modo claro */
   --color-link-light-hover: var(--color-gray-700);
-  --color-link-dark: var(--color-accent); /* Enlaces en modo oscuro */
-  --color-link-dark-hover: var(--color-accent-hover);
+  --color-link-dark: var(--color-text-dark); /* Enlaces en modo oscuro */
+  --color-link-dark-hover: var(--color-gray-300);
 
   /* Line heights */
   --line-height-11: 2.75rem;

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 @plugin "@tailwindcss/forms";
 @plugin '@tailwindcss/typography';
 @source '../node_modules/pliny';
@@ -11,41 +11,47 @@
   --font-body: var(--font-source-serif), serif;
 
   /* Colores principales */
-  --color-accent: #faff00;        /* Amarillo fosforescente */
-  --color-accent-hover: #e0e500;  /* Amarillo fosforescente hover */
-  --color-accent-dark: #c0c000;   /* Amarillo fosforescente en modo oscuro */
-  
+  --color-accent: #faff00; /* Amarillo fosforescente */
+  --color-accent-hover: #e0e500; /* Amarillo fosforescente hover */
+  --color-accent-dark: #c0c000; /* Amarillo fosforescente en modo oscuro */
+
   /* Kraft-inspired primary (cálido, terroso, papel) */
-  --color-primary-50:  #ffffd0;   /* amarillo muy claro */
+  --color-primary-50: #ffffd0; /* amarillo muy claro */
   --color-primary-100: #ffffc0;
   --color-primary-200: #ffffa0;
   --color-primary-300: #ffff80;
-  --color-primary-400: #ffff40;   /* amarillo brillante */
-  --color-primary-500: var(--color-accent);   /* amarillo fluorescente (base) */
-  --color-primary-600: var(--color-accent-hover);   /* amarillo más saturado */
-  --color-primary-700: var(--color-accent-dark);   /* amarillo con verde */
-  --color-primary-800: #a0a000;   /* ocre */
-  --color-primary-900: #808000;   /* oliva */
-  --color-primary-950: #606000;   /* verde oliva oscuro */
+  --color-primary-400: #ffff40; /* amarillo brillante */
+  --color-primary-500: var(--color-accent); /* amarillo fluorescente (base) */
+  --color-primary-600: var(--color-accent-hover); /* amarillo más saturado */
+  --color-primary-700: var(--color-accent-dark); /* amarillo con verde */
+  --color-primary-800: #a0a000; /* ocre */
+  --color-primary-900: #808000; /* oliva */
+  --color-primary-950: #606000; /* verde oliva oscuro */
 
   /* Neutros tipo carbón / tinta / papel */
-  --color-gray-50:  oklch(0.96 0 270);  /* gris papel - fondo claro */
-  --color-gray-100: oklch(0.90 0 270);
-  --color-gray-200: oklch(0.80 0 270);
-  --color-gray-300: oklch(0.70 0 270);
-  --color-gray-400: oklch(0.60 0 270);
-  --color-gray-500: oklch(0.50 0 270);  /* neutral */
-  --color-gray-600: oklch(0.40 0 270);  /* carbón */
-  --color-gray-700: oklch(0.30 0 270);  /* tinta */
-  --color-gray-800: oklch(0.20 0 270);  /* casi negro */
-  --color-gray-900: oklch(0.10 0 270);  /* negro profundo */
-  --color-gray-950: oklch(0.05 0 270);  /* negro absoluto */
+  --color-gray-50: oklch(0.96 0 270); /* gris papel - fondo claro */
+  --color-gray-100: oklch(0.9 0 270);
+  --color-gray-200: oklch(0.8 0 270);
+  --color-gray-300: oklch(0.7 0 270);
+  --color-gray-400: oklch(0.6 0 270);
+  --color-gray-500: oklch(0.5 0 270); /* neutral */
+  --color-gray-600: oklch(0.4 0 270); /* carbón */
+  --color-gray-700: oklch(0.3 0 270); /* tinta */
+  --color-gray-800: oklch(0.2 0 270); /* casi negro */
+  --color-gray-900: oklch(0.1 0 270); /* negro profundo */
+  --color-gray-950: oklch(0.05 0 270); /* negro absoluto */
 
   /* Variables específicas para facilitar uso */
-  --color-bg-light: var(--color-gray-50);      /* Fondo en modo claro */
-  --color-bg-dark: var(--color-gray-900);      /* Fondo en modo oscuro */
-  --color-text-light: var(--color-gray-900);   /* Texto en modo claro */
-  --color-text-dark: var(--color-gray-50);     /* Texto en modo oscuro */
+  --color-bg-light: var(--color-gray-50); /* Fondo en modo claro */
+  --color-bg-dark: var(--color-gray-900); /* Fondo en modo oscuro */
+  --color-text-light: var(--color-gray-900); /* Texto en modo claro */
+  --color-text-dark: var(--color-gray-50); /* Texto en modo oscuro */
+
+  /* Colores de enlaces */
+  --color-link-light: var(--color-text-light); /* Enlaces en modo claro */
+  --color-link-light-hover: var(--color-gray-700);
+  --color-link-dark: var(--color-accent); /* Enlaces en modo oscuro */
+  --color-link-dark-hover: var(--color-accent-hover);
 
   /* Line heights */
   --line-height-11: 2.75rem;
@@ -58,7 +64,6 @@
   --z-70: 70;
   --z-80: 80;
 }
-
 
 /*
   The default border color has changed to `currentColor` in Tailwind CSS v4,
@@ -90,27 +95,63 @@
   }
 
   /* Títulos con Playfair Display */
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-family: var(--font-titles);
     font-weight: 700;
     letter-spacing: var(--tracking-tight);
   }
 
   /* Cuerpo con Source Serif 4 */
-  html, body, p, li, blockquote, .font-serif {
+  html,
+  body,
+  p,
+  li,
+  blockquote,
+  .font-serif {
     font-family: var(--font-body);
+  }
+
+  body {
+    color: var(--color-text-light);
+    background-color: var(--color-bg-light);
+  }
+
+  html.dark body {
+    color: var(--color-text-dark);
+    background-color: var(--color-bg-dark);
+  }
+
+  a {
+    color: var(--color-link-light);
+  }
+
+  a:hover {
+    color: var(--color-link-light-hover);
+  }
+
+  html.dark a {
+    color: var(--color-link-dark);
+  }
+
+  html.dark a:hover {
+    color: var(--color-link-dark-hover);
   }
 }
 
 @layer utilities {
   .prose {
     & a {
-      color: var(--color-primary-500);
+      color: var(--color-link-light);
       &:hover {
-        color: var(--color-primary-600);
+        color: var(--color-link-light-hover);
       }
       & code {
-        color: var(--color-primary-400);
+        color: var(--color-link-light-hover);
       }
     }
     & :where(h1, h2) {
@@ -129,12 +170,12 @@
 
   .prose-invert {
     & a {
-      color: var(--color-primary-500);
+      color: var(--color-link-dark);
       &:hover {
-        color: var(--color-primary-400);
+        color: var(--color-link-dark-hover);
       }
       & code {
-        color: var(--color-primary-400);
+        color: var(--color-link-dark-hover);
       }
     }
     & :where(h1, h2, h3, h4, h5, h6) {
@@ -359,7 +400,9 @@ html.dark #menu-button:hover {
   visibility: visible !important;
   opacity: 1 !important;
   transform-origin: bottom right !important;
-  transition: transform 0.2s ease-out, opacity 0.2s ease-out !important;
+  transition:
+    transform 0.2s ease-out,
+    opacity 0.2s ease-out !important;
 }
 
 #story-menu.hidden {
@@ -418,7 +461,7 @@ html.dark .story-menu-item.active {
 }
 
 .story-menu-item.active::before {
-  content: '' !important;
+  content: "" !important;
   position: absolute !important;
   left: 0 !important;
   top: 0 !important;

--- a/layouts/AlternativeLayout.tsx
+++ b/layouts/AlternativeLayout.tsx
@@ -131,9 +131,9 @@ export default function AlternativeLayout({ content, next, prev, children }: Alt
                 <div className="flex justify-between items-center">
                   <div className="flex-1">
                     {prev && (
-                      <Link 
+                      <Link
                         href={`/microcuento/${prev.slug.current}`}
-                        className="text-left text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+                        className="text-left hover:underline transition-colors"
                       >
                         <div className="text-xs uppercase tracking-wide mb-1">Anterior</div>
                         <div className="font-medium">{prev.title}</div>
@@ -143,9 +143,9 @@ export default function AlternativeLayout({ content, next, prev, children }: Alt
                   
                   <div className="flex-1 text-right">
                     {next && (
-                      <Link 
+                      <Link
                         href={`/microcuento/${next.slug.current}`}
-                        className="text-right text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+                        className="text-right hover:underline transition-colors"
                       >
                         <div className="text-xs uppercase tracking-wide mb-1">Siguiente</div>
                         <div className="font-medium">{next.title}</div>

--- a/layouts/ChronologicalLayout.tsx
+++ b/layouts/ChronologicalLayout.tsx
@@ -90,15 +90,12 @@ export default function ChronologicalLayout({
               {/* Columna de contenido */}
               <div>
                 <h2 className="text-xl md:text-2xl font-bold mb-2">
-                  <Link
-                    href={item.href}
-                    className="text-gray-900 dark:text-gray-100 hover:text-primary-600 dark:hover:text-primary-400"
-                  >
+                  <Link href={item.href} className="hover:underline">
                     {item.title}
                   </Link>
                 </h2>
                 <div className="text-sm text-gray-600 dark:text-gray-400 mb-2">
-                  Por: <Link href={item.authorHref} className="hover:text-primary-600 dark:hover:text-primary-400">
+                  Por: <Link href={item.authorHref} className="hover:underline">
                     {item.authorName}
                   </Link>
                 </div>

--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -131,7 +131,7 @@ export default function ListLayout({
                   <div className="space-y-3 xl:col-span-3">
                     <div>
                       <h3 className="text-2xl leading-8 font-bold tracking-tight">
-                        <Link href={`/${path}`} className="text-gray-900 dark:text-gray-100">
+                        <Link href={`/${path}`}> 
                           {title}
                         </Link>
                       </h3>

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -141,7 +141,7 @@ export default function ListLayoutWithTags({
                       <div className="space-y-3">
                         <div>
                           <h2 className="text-2xl leading-8 font-bold tracking-tight">
-                            <Link href={`/${path}`} className="text-gray-900 dark:text-gray-100">
+                            <Link href={`/${path}`}> 
                               {title}
                             </Link>
                           </h2>

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -162,21 +162,15 @@ export default async function PostLayout({
                         )}
                         <dl className="text-sm leading-5 font-medium whitespace-nowrap">
                           <dt className="sr-only">Name</dt>
-                          <dd className="text-black">
-                            <Link
-                              href={`/autor/${author.slug}`}
-                              className="text-black hover:text-gray-700"
-                            >
+                          <dd>
+                            <Link href={`/autor/${author.slug}`} className="hover:underline">
                               {author.name}
                             </Link>
                           </dd>
                           <dt className="sr-only">Twitter</dt>
                           <dd>
                             {author.twitter && (
-                              <Link
-                                href={author.twitter}
-                                className="text-black hover:text-gray-700"
-                              >
+                              <Link href={author.twitter} className="hover:underline">
                                 {author.twitter
                                   .replace("https://twitter.com/", "@")
                                   .replace("https://x.com/", "@")}
@@ -196,7 +190,7 @@ export default async function PostLayout({
                   className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
                 >
                   {showDropCap ? (
-                    <div className="prose dark:prose-invert max-w-none [&_p]:!text-lg [&_p]:!leading-7 md:[&_p]:!text-base md:[&_p]:!leading-7 [&_a]:!text-gray-800 [&_a]:!no-underline hover:[&_a]:!underline dark:[&_a]:!text-yellow-400 dark:hover:[&_a]:!text-yellow-300">
+                    <div className="prose dark:prose-invert max-w-none [&_p]:!text-lg [&_p]:!leading-7 md:[&_p]:!text-base md:[&_p]:!leading-7 [&_a]:!no-underline hover:[&_a]:underline">
                       {(() => {
                         // Si children es un solo div (como PortableText suele hacer), aplica drop-cap al primer <p>
                         if (
@@ -269,7 +263,7 @@ export default async function PostLayout({
                       })()}
                     </div>
                   ) : (
-                    <div className="prose dark:prose-invert max-w-none [&_p]:!text-lg [&_p]:!leading-7 md:[&_p]:!text-base md:[&_p]:!leading-7 [&_a]:!text-gray-800 [&_a]:!no-underline hover:[&_a]:!underline dark:[&_a]:!text-yellow-400 dark:hover:[&_a]:!text-yellow-300">
+                    <div className="prose dark:prose-invert max-w-none [&_p]:!text-lg [&_p]:!leading-7 md:[&_p]:!text-base md:[&_p]:!leading-7 [&_a]:!no-underline hover:[&_a]:underline">
                       {children}
                     </div>
                   )}
@@ -302,7 +296,7 @@ export default async function PostLayout({
                           <h2 className="text-xs tracking-wide text-gray-500 uppercase dark:text-gray-400">
                             {prevLabel}
                           </h2>
-                          <div className="text-black hover:text-gray-700">
+                          <div>
                             <Link href={`/${prev.path}`}>{prev.title}</Link>
                           </div>
                         </div>
@@ -312,7 +306,7 @@ export default async function PostLayout({
                           <h2 className="text-xs tracking-wide text-gray-500 uppercase dark:text-gray-400">
                             {nextLabel}
                           </h2>
-                          <div className="text-black hover:text-gray-700">
+                          <div>
                             <Link href={`/${next.path}`}>{next.title}</Link>
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- mejorar variables de colores para modo claro y oscuro
- ajustar estilos base de cuerpo y enlaces
- unificar colores en clases `prose`

## Testing
- `yarn lint` *(fails: proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6840aee0674083219f78beb153622134