### PR TITLE
Add organization structured data

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import ConditionalHeader from '@/components/ConditionalHeader'
 import SectionContainer from '@/components/SectionContainer'
 import Footer from '@/components/Footer'
 import siteMetadata from '@/data/siteMetadata'
+import OrganizationSchema from '@/components/OrganizationSchema'
 import { ThemeProviders } from './theme-providers'
 import { Metadata } from 'next'
 import Script from 'next/script'
@@ -140,6 +141,7 @@ export default function RootLayout({
           type="application/rss+xml"
           href={`${basePath}/feed.xml`}
         />
+        <OrganizationSchema />
       </head>
       <body className="antialiased font-serif">
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>

--- a/components/OrganizationSchema.tsx
+++ b/components/OrganizationSchema.tsx
@@ -1,0 +1,33 @@
+import siteMetadata from '@/data/siteMetadata'
+
+export default function OrganizationSchema() {
+  const sameAs = [
+    siteMetadata.twitter,
+    siteMetadata.github,
+    siteMetadata.instagram,
+    siteMetadata.threads,
+    siteMetadata.bluesky,
+    siteMetadata.facebook,
+    siteMetadata.linkedin,
+    siteMetadata.x,
+    siteMetadata.youtube,
+    siteMetadata.mastodon,
+    siteMetadata.medium,
+  ].filter(Boolean)
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: siteMetadata.title,
+    url: siteMetadata.siteUrl,
+    logo: siteMetadata.siteLogo,
+    ...(sameAs.length > 0 && { sameAs }),
+  }
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- render Organization schema with site info
- inject OrganizationSchema component in `<head>`

## Testing
- `npx prettier --write components/OrganizationSchema.tsx app/layout.tsx`
- `yarn lint` *(fails: Error when performing the request)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd4957f48321b875c0e92e3079f6