### PR TITLE
Cambiar nombre de vista Cronológica y mostrar total

### DIFF
--- a/app/cronologico/page.tsx
+++ b/app/cronologico/page.tsx
@@ -56,7 +56,7 @@ export default async function CronologicoPage({ searchParams }: PageProps) {
 </p>
         </div>
         {/* Botones de cambio de vista */}
-        <ViewToggle />
+        <ViewToggle total={allRelatos.length} />
         
         {/* Vista cronológica */}
         <div className="container">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import {
   getFeaturedAndNonFeaturedRelatos,
   getAllMicrocuentos,
+  getAllRelatosForChronological,
 } from "../lib/sanity";
 // import { getSortedProjects, getFeaturedProject, getNonFeaturedProjects } from '@/data/projectsData'
 //import Card from '@/components/Card'
@@ -56,6 +57,8 @@ export default async function Page() {
   let featuredProject: CardProps | null = null;
   let nonFeaturedProjects: CardProps[] = [];
   const allMicrocuentos = await getAllMicrocuentos();
+  const allRelatos = await getAllRelatosForChronological();
+  const totalRelatos = allRelatos.length;
 
   try {
     console.log("Obteniendo datos desde Sanity");
@@ -106,7 +109,7 @@ export default async function Page() {
         </div>
 
         {/* Botones de cambio de vista */}
-        <ViewToggle />
+        <ViewToggle total={totalRelatos} />
 
         {/* Primera fila: 3 relatos sin slider */}
         <div className="container pb-6">

--- a/components/ViewToggle.tsx
+++ b/components/ViewToggle.tsx
@@ -4,7 +4,11 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { LayoutGrid, CalendarClock } from 'lucide-react'
 
-export default function ViewToggle() {
+interface ViewToggleProps {
+  total?: number
+}
+
+export default function ViewToggle({ total }: ViewToggleProps) {
   const pathname = usePathname()
   const isChronological = pathname === '/cronologico'
 
@@ -30,7 +34,7 @@ export default function ViewToggle() {
         }`}
       >
         <CalendarClock className="w-4 h-4" />
-        Cronológica
+        {`Todos${typeof total === 'number' ? ` (${total})` : ''}`}
       </Link>
     </div>
   )


### PR DESCRIPTION
## Summary
- rename Cronológica button to Todos and show total count
- pass relatos count to the view toggle on home and chronological pages

## Testing
- `yarn lint` *(fails: Error when performing the request to repo.yarnpkg.com)*

------
https://chatgpt.com/codex/tasks/task_e_6840e3fe762c83218fd2a0e590ebce38