### PR TITLE
Add share menu to FixedNavMenu

### DIFF
--- a/components/FixedNavMenu.tsx
+++ b/components/FixedNavMenu.tsx
@@ -45,6 +45,7 @@ export default function FixedNavMenu({
 }: FixedNavMenuProps) {
   const [readingProgress, setReadingProgress] = useState(0)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
 
   // Reduce title to first two words
@@ -101,7 +102,7 @@ export default function FixedNavMenu({
         <div className="flex items-center justify-between p-2">
           <div className="flex items-center space-x-2">
             {authorAvatar ? (
-              <Link href={`/autor/${author}`}> 
+              <Link href={`/autor/${author}`}>
                 <Image
                   src={authorAvatar}
                   alt={authorName || 'Author'}
@@ -156,41 +157,147 @@ export default function FixedNavMenu({
               })()}
             </span>
           </div>
-          <button
-            onClick={() => {
-              sendGAEvent({
-                action: 'toggle_author_menu',
-                category: 'AuthorMenu',
-                label: authorName || author,
-                value: !menuOpen ? 'opened' : 'closed',
-              })
-              setMenuOpen(!menuOpen)
-            }}
-            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
-            aria-label="Toggle menu"
-          >
-            {menuOpen ? (
-              // Arrow down icon when open
+          <div className="flex space-x-2">
+            <button
+              onClick={() => {
+                sendGAEvent({
+                  action: 'toggle_author_menu',
+                  category: 'AuthorMenu',
+                  label: authorName || author,
+                  value: !menuOpen ? 'opened' : 'closed',
+                })
+                setMenuOpen(!menuOpen)
+                setShareOpen(false)
+              }}
+              className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+              aria-label="Toggle menu"
+            >
+              {menuOpen ? (
+                // Arrow down icon when open
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  className="h-5 w-5 text-gray-500 hover:text-primary-500"
+                >
+                  <path d="M5 8l5 5 5-5H5z" />
+                </svg>
+              ) : (
+                // Arrow up icon when closed
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  className="h-5 w-5 text-gray-500 hover:text-primary-500"
+                >
+                  <path d="M5 12l5-5 5 5H5z" />
+                </svg>
+              )}
+            </button>
+            <button
+              onClick={() => setShareOpen(!shareOpen)}
+              className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+              aria-label="Compartir"
+            >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
+                viewBox="0 0 24 24"
                 fill="currentColor"
                 className="h-5 w-5 text-gray-500 hover:text-primary-500"
               >
-                <path d="M5 8l5 5 5-5H5z" />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                />
               </svg>
-            ) : (
-              // Arrow up icon when closed
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                className="h-5 w-5 text-gray-500 hover:text-primary-500"
-              >
-                <path d="M5 12l5-5 5 5H5z" />
+            </button>
+          </div>
+        </div>
+
+        {/* Share panel */}
+        <div
+          className={`overflow-hidden transition-[max-height] duration-200 ease-in-out ${
+            shareOpen ? 'max-h-40' : 'max-h-0'
+          }`}
+        >
+          <div className="bg-white dark:bg-gray-900 p-4 border-t border-gray-200 dark:border-gray-700 flex justify-around">
+            <button
+              onClick={() => {
+                if (typeof window !== 'undefined') {
+                  const url = window.location.href
+                  window.open(
+                    `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`,
+                    '_blank',
+                    'noopener,noreferrer,width=600,height=400'
+                  )
+                  sendGAEvent({ action: 'share_facebook', category: 'Share', label: slug })
+                }
+              }}
+              className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+              aria-label="Facebook"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5">
+                <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
               </svg>
-            )}
-          </button>
+            </button>
+            <button
+              onClick={() => {
+                if (typeof window !== 'undefined') {
+                  const url = window.location.href
+                  window.open(
+                    `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`,
+                    '_blank',
+                    'noopener,noreferrer,width=600,height=400'
+                  )
+                  sendGAEvent({ action: 'share_twitter', category: 'Share', label: slug })
+                }
+              }}
+              className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+              aria-label="Twitter"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5">
+                <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z" />
+              </svg>
+            </button>
+            <button
+              onClick={() => {
+                if (typeof window !== 'undefined') {
+                  const url = window.location.href
+                  window.open(
+                    `https://wa.me/?text=${encodeURIComponent(url)}`,
+                    '_blank',
+                    'noopener,noreferrer'
+                  )
+                  sendGAEvent({ action: 'share_whatsapp', category: 'Share', label: slug })
+                }
+              }}
+              className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+              aria-label="WhatsApp"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5">
+                <path d="M17.472 14.614c-.297-.149-1.758-.867-2.03-.967-.272-.099-.471-.148-.671.15-.199.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.149-1.255-.462-2.39-1.475-.883-.788-1.48-1.757-1.653-2.054-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.521.15-.174.199-.298.298-.497.099-.198.05-.372-.025-.521-.074-.149-.671-1.611-.918-2.206-.242-.58-.487-.5-.671-.508-.173-.008-.372-.009-.571-.009-.199 0-.521.075-.795.373-.273.298-1.042 1.016-1.042 2.478 0 1.462 1.067 2.875 1.215 3.074.149.198 2.095 3.2 5.072 4.487.709.306 1.263.489 1.694.626.712.227 1.36.195 1.872.118.571-.085 1.758-.719 2.006-1.413.248-.695.248-1.291.173-1.413-.074-.123-.272-.198-.57-.347zM11.997 1.929c-5.51 0-9.969 4.458-9.969 9.969a9.95 9.95 0 001.369 5.061L.939 22.154l5.348-2.811a9.96 9.96 0 005.71 1.653c5.51 0 9.97-4.459 9.97-9.97S17.508 1.929 11.997 1.929z" />
+              </svg>
+            </button>
+            <button
+              onClick={() => {
+                if (typeof window !== 'undefined') {
+                  const url = window.location.href
+                  navigator.clipboard.writeText(url)
+                  alert('Enlace copiado al portapapeles')
+                  sendGAEvent({ action: 'share_copy', category: 'Share', label: slug })
+                }
+              }}
+              className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+              aria-label="Copiar"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5">
+                <path d="M16 1H4a1 1 0 00-1 1v14h2V3h11V1z" />
+                <path d="M21 5H8a1 1 0 00-1 1v16a1 1 0 001 1h13a1 1 0 001-1V6a1 1 0 00-1-1zm-1 16H9V7h11v14z" />
+              </svg>
+            </button>
+          </div>
         </div>
 
         {/* Animated related posts panel */}

--- a/components/FixedNavMenu.tsx
+++ b/components/FixedNavMenu.tsx
@@ -178,7 +178,7 @@ export default function FixedNavMenu({
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 20 20"
                   fill="currentColor"
-                  className="h-5 w-5 text-gray-500 hover:text-primary-500"
+                  className="h-5 w-5 text-black dark:text-gray-50 hover:text-primary-500"
                 >
                   <path d="M5 8l5 5 5-5H5z" />
                 </svg>
@@ -188,22 +188,31 @@ export default function FixedNavMenu({
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 20 20"
                   fill="currentColor"
-                  className="h-5 w-5 text-gray-500 hover:text-primary-500"
+                  className="h-5 w-5 text-black dark:text-gray-50 hover:text-primary-500"
                 >
                   <path d="M5 12l5-5 5 5H5z" />
                 </svg>
               )}
             </button>
             <button
-              onClick={() => setShareOpen(!shareOpen)}
-              className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+              onClick={() => {
+                sendGAEvent({
+                  action: 'toggle_share_menu',
+                  category: 'ShareMenu',
+                  label: slug,
+                  value: !shareOpen ? 'opened' : 'closed',
+                })
+                setShareOpen(!shareOpen)
+                setMenuOpen(false)
+              }}
+              className="p-1 rounded bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
               aria-label="Compartir"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"
-                className="h-5 w-5 text-gray-500 hover:text-primary-500"
+                className="h-5 w-5 text-gray-700 dark:text-gray-50"
               >
                 <path
                   strokeLinecap="round"
@@ -238,7 +247,7 @@ export default function FixedNavMenu({
               className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
               aria-label="Facebook"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5 text-[#1877F2]">
                 <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
               </svg>
             </button>
@@ -257,7 +266,7 @@ export default function FixedNavMenu({
               className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
               aria-label="Twitter"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5 text-[#1DA1F2]">
                 <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z" />
               </svg>
             </button>
@@ -276,7 +285,7 @@ export default function FixedNavMenu({
               className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
               aria-label="WhatsApp"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5 text-[#25D366]">
                 <path d="M17.472 14.614c-.297-.149-1.758-.867-2.03-.967-.272-.099-.471-.148-.671.15-.199.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.149-1.255-.462-2.39-1.475-.883-.788-1.48-1.757-1.653-2.054-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.521.15-.174.199-.298.298-.497.099-.198.05-.372-.025-.521-.074-.149-.671-1.611-.918-2.206-.242-.58-.487-.5-.671-.508-.173-.008-.372-.009-.571-.009-.199 0-.521.075-.795.373-.273.298-1.042 1.016-1.042 2.478 0 1.462 1.067 2.875 1.215 3.074.149.198 2.095 3.2 5.072 4.487.709.306 1.263.489 1.694.626.712.227 1.36.195 1.872.118.571-.085 1.758-.719 2.006-1.413.248-.695.248-1.291.173-1.413-.074-.123-.272-.198-.57-.347zM11.997 1.929c-5.51 0-9.969 4.458-9.969 9.969a9.95 9.95 0 001.369 5.061L.939 22.154l5.348-2.811a9.96 9.96 0 005.71 1.653c5.51 0 9.97-4.459 9.97-9.97S17.508 1.929 11.997 1.929z" />
               </svg>
             </button>
@@ -292,7 +301,7 @@ export default function FixedNavMenu({
               className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
               aria-label="Copiar"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-5 w-5 text-gray-700">
                 <path d="M16 1H4a1 1 0 00-1 1v14h2V3h11V1z" />
                 <path d="M21 5H8a1 1 0 00-1 1v16a1 1 0 001 1h13a1 1 0 001-1V6a1 1 0 00-1-1zm-1 16H9V7h11v14z" />
               </svg>


### PR DESCRIPTION
## Summary
- add `shareOpen` state and UI for share buttons
- share via Facebook, Twitter, WhatsApp or copy URL
- place new Share button next to author menu toggle

## Testing
- `yarn lint` *(fails: Error when performing the request to repo.yarnpkg.com)*

------
https://chatgpt.com/codex/tasks/task_e_68417a32b9c48321a64e6c34781a05b3