### PR TITLE
Añadir página para playlist

### DIFF
--- a/app/playlist/page.tsx
+++ b/app/playlist/page.tsx
@@ -1,0 +1,45 @@
+import SectionContainer from '@/components/SectionContainer'
+import PageTitle from '@/components/PageTitle'
+import { genPageMetadata } from 'app/seo'
+
+export const metadata = genPageMetadata({
+  title: 'Playlist',
+  description: 'Escucha la música de MarcaPágina en Spotify y YouTube.'
+})
+
+export default function PlaylistPage() {
+  return (
+    <SectionContainer>
+      <article className="mx-auto max-w-3xl">
+        <div className="space-y-8 divide-y divide-gray-200 dark:divide-gray-700">
+          <div className="pt-8 pb-8">
+            <PageTitle>Playlist</PageTitle>
+            <p className="mt-2 text-lg">
+              Selección musical para nuestros reels y lecturas. Jazz y trip hop para acompañar cada relato.
+            </p>
+            <div className="mt-8 space-y-6">
+              <div className="aspect-video">
+                <iframe
+                  className="w-full h-full rounded-md"
+                  src="https://www.youtube.com/embed/videoseries?list=PLKfzi-Ybx99YOcEfCuiwR5nEdAapExkel"
+                  title="YouTube playlist"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                />
+              </div>
+              <div className="aspect-[16/10]">
+                <iframe
+                  className="w-full h-full rounded-md"
+                  src="https://open.spotify.com/embed/playlist/1KhNqfcsSL4nHzf43T5KLI?utm_source=generator"
+                  title="Spotify playlist"
+                  allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                  loading="lazy"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+    </SectionContainer>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -40,6 +40,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: today,
     },
     {
+      url: `${siteUrl}/playlist`, // página de playlist
+      lastModified: today,
+    },
+    {
       url: `${siteUrl}/transtextos`, // página principal de Transtextos
       lastModified: today,
     },

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -41,6 +41,7 @@ const navLinks = [
     icon: <Rss className="w-4 h-4 ml-1" style={{ color: '#f26522' }} />,
   },
   { title: 'Autores', href: '/autores' },
+  { title: 'Playlist', href: '/playlist' },
   { title: 'Acerca de', href: '/acerca-de' },
 ];
 

--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -1,7 +1,8 @@
 const headerNavLinks = [
   { href: '/', title: 'Inicio' },
-  { href: '/publica', title: 'Publica con nosotros' }, 
+  { href: '/publica', title: 'Publica con nosotros' },
   { href: '/criterios-editoriales', title: 'Criterios editoriales' },
+  { href: '/playlist', title: 'Playlist' },
   { href: '/acerca-de', title: 'Acerca de' },
 ]
 

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -17,7 +17,8 @@ const siteMetadata = {
   x: '',
   twitter: 'https://x.com/marcapaginapage',
   facebook: '',
-  youtube: '',
+  youtube:
+    'https://www.youtube.com/playlist?list=PLKfzi-Ybx99YOcEfCuiwR5nEdAapExkel',
   linkedin: '',
   threads: 'https://www.threads.com/@marcapagina.page',
   instagram: 'https://www.instagram.com/marcapagina.page/',

--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is https://challenges.cloudflare.com https://www.googletagmanager.com;
   script-src-elem 'self' 'unsafe-inline' https://challenges.cloudflare.com https://www.googletagmanager.com;
-  frame-src 'self' https://challenges.cloudflare.com;
+  frame-src 'self' https://challenges.cloudflare.com https://www.youtube.com https://open.spotify.com;
   style-src 'self' 'unsafe-inline';
   img-src * blob: data:;
   media-src *.s3.amazonaws.com;


### PR DESCRIPTION
## Summary
- create `/playlist` page to embed Spotify and YouTube
- link playlist page in the header and mobile menu
- add playlist page to sitemap and metadata
- update CSP to allow youtube and spotify iframes

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com/3.6.1/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_e_684229a968d883218f9cd4078f694df3