### PR TITLE
Oculta imagen en Transtextos

### DIFF
--- a/app/relato/[slug]/page.tsx
+++ b/app/relato/[slug]/page.tsx
@@ -158,8 +158,8 @@ export default async function Page(props: {
     tags: post.tags || [],
     draft: false,
     summary: post.summary || '',
-    images: post.image ? [post.image] : [],
-    image: post.image,
+    images: isTranstextos ? [] : post.image ? [post.image] : [],
+    image: isTranstextos ? undefined : post.image,
     authors: [post.author.name],
     slug: post.slug.current,
     path: `relato/${post.slug.current}`,
@@ -185,7 +185,7 @@ export default async function Page(props: {
     datePublished: post.date,
     dateModified: post.date,
     description: post.summary,
-    image: post.image,
+    image: isTranstextos ? undefined : post.image,
     url: siteMetadata.siteUrl + `/relato/${slug}`,
     author: authorDetails.map((a) => ({ '@type': 'Person', name: a.name }))
   }


### PR DESCRIPTION
## Summary
- no mostrar imagen destacada si el relato pertenece al sitio Transtextos

## Testing
- `npx prettier --write app/relato/[slug]/page.tsx` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `yarn lint` *(fails: fetch error)*

------
https://chatgpt.com/codex/tasks/task_e_6842ebf7b6b483218ff4ef33f8371fc1