### PR TITLE
Añadir breadcrumbs y mejorar JSON-LD

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Playfair_Display, Source_Serif_4 } from 'next/font/google'
 import { Analytics, AnalyticsConfig } from 'pliny/analytics'
 import { SearchProvider, SearchConfig } from 'pliny/search'
 import ConditionalHeader from '@/components/ConditionalHeader'
+import Breadcrumbs from '@/components/Breadcrumbs'
 import SectionContainer from '@/components/SectionContainer'
 import Footer from '@/components/Footer'
 import siteMetadata from '@/data/siteMetadata'
@@ -148,6 +149,9 @@ export default function RootLayout({
           <ThemeProviders>
             <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />
             <ConditionalHeader />
+            <SectionContainer>
+              <Breadcrumbs />
+            </SectionContainer>
             <SearchProvider searchConfig={siteMetadata.search as SearchConfig}>
               <main className="mb-auto font-serif">{children}</main>
             </SearchProvider>

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import siteMetadata from '@/data/siteMetadata'
+
+const labelMap: Record<string, string> = {
+  relato: 'Relatos',
+  articulo: 'Artículos',
+  autores: 'Autores',
+  autor: 'Autor',
+  'acerca-de': 'Acerca de',
+  cronologico: 'Cronológico',
+  playlist: 'Playlist',
+  transtextos: 'Transtextos',
+}
+
+function formatLabel(segment: string) {
+  return labelMap[segment] || segment.replace(/-/g, ' ')
+}
+
+export default function Breadcrumbs() {
+  const pathname = usePathname()
+  const segments = pathname.split('/').filter(Boolean)
+  if (segments.length === 0) return null
+
+  const crumbs = segments.map((seg, index) => {
+    return {
+      href: '/' + segments.slice(0, index + 1).join('/'),
+      label: formatLabel(seg),
+    }
+  })
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Inicio',
+        item: siteMetadata.siteUrl,
+      },
+      ...crumbs.map((c, idx) => ({
+        '@type': 'ListItem',
+        position: idx + 2,
+        name: c.label,
+        item: siteMetadata.siteUrl.replace(/\/$/, '') + c.href,
+      })),
+    ],
+  }
+
+  return (
+    <>
+      <nav aria-label="Breadcrumb" className="mb-6 text-sm text-gray-500 dark:text-gray-400">
+        <ol className="flex flex-wrap items-center gap-1">
+          <li>
+            <Link href="/" className="hover:underline">
+              Inicio
+            </Link>
+          </li>
+          {crumbs.map((c, idx) => (
+            <li key={c.href} className="flex items-center gap-1">
+              <span className="mx-1">/</span>
+              {idx === crumbs.length - 1 ? (
+                <span aria-current="page" className="text-gray-700 dark:text-gray-300">
+                  {c.label}
+                </span>
+              ) : (
+                <Link href={c.href} className="hover:underline">
+                  {c.label}
+                </Link>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+    </>
+  )
+}

--- a/components/OrganizationSchema.tsx
+++ b/components/OrganizationSchema.tsx
@@ -18,11 +18,28 @@ export default function OrganizationSchema() {
 
   const jsonLd = {
     '@context': 'https://schema.org',
-    '@type': 'Organization',
-    name: siteMetadata.title,
-    url: siteMetadata.siteUrl,
-    logo: siteMetadata.siteLogo,
-    ...(sameAs.length > 0 && { sameAs }),
+    '@graph': [
+      {
+        '@type': 'Organization',
+        '@id': siteMetadata.siteUrl,
+        name: siteMetadata.title,
+        url: siteMetadata.siteUrl,
+        logo: {
+          '@type': 'ImageObject',
+          url: siteMetadata.siteLogo,
+        },
+        ...(sameAs.length > 0 && { sameAs }),
+      },
+      {
+        '@type': 'WebSite',
+        '@id': `${siteMetadata.siteUrl}#website`,
+        url: siteMetadata.siteUrl,
+        name: siteMetadata.title,
+        publisher: { '@id': siteMetadata.siteUrl },
+        inLanguage: siteMetadata.language,
+        description: siteMetadata.description,
+      },
+    ],
   }
 
   return (


### PR DESCRIPTION
## Summary
- añadir component Breadcrumbs con esquema JSON-LD
- incluir breadcrumbs en el layout principal
- mejorar OrganizationSchema con datos de WebSite

## Testing
- `npx prettier -w components/Breadcrumbs.tsx components/OrganizationSchema.tsx app/layout.tsx` *(falló: Cannot find package 'prettier-plugin-tailwindcss')*
- `yarn lint` *(falló al instalar dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_68434cb8d08c8321918bc2340a323260