### PR TITLE
Fix word overflow in PostLayout

### DIFF
--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -188,7 +188,7 @@ export default async function PostLayout({
               <div className="divide-y divide-gray-200 xl:col-span-3 xl:row-span-2 xl:pb-0 dark:divide-gray-700">
                 <div
                   id="post-content"
-                  className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+                  className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 break-words"
                 >
                   {showDropCap ? (
                     <div className="prose dark:prose-invert max-w-none [&_p]:!text-lg [&_p]:!leading-7 md:[&_p]:!text-base md:[&_p]:!leading-7 [&_a]:!no-underline hover:[&_a]:underline">


### PR DESCRIPTION
## Summary
- allow word breaks in `PostLayout`

## Testing
- `yarn lint` *(fails: Error when performing the request to https://repo.yarnpkg.com)*

------
https://chatgpt.com/codex/tasks/task_e_684c5577ad588321869f04b0778b3ac9