### PR TITLE
Mover LanguageDropdown fuera del menú

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import Footer from '@/components/Footer'
 import siteMetadata from '@/data/siteMetadata'
 import OrganizationSchema from '@/components/OrganizationSchema'
 import { ThemeProviders } from './theme-providers'
+import LanguageDropdown from '@/components/LanguageDropdown'
 import { Metadata } from 'next'
 import Script from 'next/script'
 import { ThemeProvider } from 'next-themes'
@@ -150,7 +151,10 @@ export default function RootLayout({
             <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />
             <ConditionalHeader />
             <SectionContainer>
-              <Breadcrumbs />
+              <div className="flex items-start justify-between">
+                <Breadcrumbs />
+                <LanguageDropdown />
+              </div>
             </SectionContainer>
             <SearchProvider searchConfig={siteMetadata.search as SearchConfig}>
               <main className="mb-auto font-serif">{children}</main>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,7 +14,6 @@ import {
 import { useState } from 'react'
 import ThemeToggle from './ThemeToggle'
 import PublishDropdown from './PublishDropdown'
-import LanguageDropdown from './LanguageDropdown'
 
 const socialLinks = [
   {
@@ -157,7 +156,6 @@ const Header = () => {
               ))}
               <ProjectDropdown />
               <ThemeToggle />
-              <LanguageDropdown />
               <PublishDropdown isMobile={false} />
             </div>
             
@@ -215,10 +213,6 @@ const Header = () => {
                           {link.title}
                         </CustomLink>
                       ))}
-                    </div>
-                    <div className="flex flex-col items-center gap-3 mt-4">
-                      <span className="text-gray-500 dark:text-gray-400 text-sm">Idioma</span>
-                      <LanguageDropdown inMobileMenu={true} />
                     </div>
                   </nav>
                   <div className="flex gap-6 justify-center mt-8">


### PR DESCRIPTION
## Summary
- colocar LanguageDropdown junto a las breadcrumbs
- quitar LanguageDropdown del header y del menú móvil

## Testing
- `yarn lint` *(falla: no se pudo descargar dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_6853e9bee5608321a3ba01acb1f5b5d1