### PR TITLE
Mover selector de idioma junto a breadcrumbs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { Analytics, AnalyticsConfig } from 'pliny/analytics'
 import { SearchProvider, SearchConfig } from 'pliny/search'
 import ConditionalHeader from '@/components/ConditionalHeader'
 import Breadcrumbs from '@/components/Breadcrumbs'
+import LanguageDropdown from '@/components/LanguageDropdown'
 import SectionContainer from '@/components/SectionContainer'
 import Footer from '@/components/Footer'
 import siteMetadata from '@/data/siteMetadata'
@@ -150,7 +151,10 @@ export default function RootLayout({
             <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />
             <ConditionalHeader />
             <SectionContainer>
-              <Breadcrumbs />
+              <div className="flex items-start justify-between">
+                <Breadcrumbs />
+                <LanguageDropdown isMobile />
+              </div>
             </SectionContainer>
             <SearchProvider searchConfig={siteMetadata.search as SearchConfig}>
               <main className="mb-auto font-serif">{children}</main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -151,7 +151,7 @@ export default function RootLayout({
             <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />
             <ConditionalHeader />
             <SectionContainer>
-              <div className="flex items-start justify-between">
+              <div className="flex items-center justify-between mt-4">
                 <Breadcrumbs />
                 <LanguageDropdown isMobile />
               </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,7 +14,6 @@ import {
 import { useState } from 'react'
 import ThemeToggle from './ThemeToggle'
 import PublishDropdown from './PublishDropdown'
-import LanguageDropdown from './LanguageDropdown'
 
 const socialLinks = [
   {
@@ -157,7 +156,6 @@ const Header = () => {
               ))}
               <ProjectDropdown />
               <ThemeToggle />
-              <LanguageDropdown />
               <PublishDropdown isMobile={false} />
             </div>
             
@@ -215,10 +213,6 @@ const Header = () => {
                           {link.title}
                         </CustomLink>
                       ))}
-                    </div>
-                    <div className="flex flex-col items-center gap-3 mt-4">
-                      <span className="text-gray-500 dark:text-gray-400 text-sm">Idioma</span>
-                      <LanguageDropdown inMobileMenu={true} />
                     </div>
                   </nav>
                   <div className="flex gap-6 justify-center mt-8">

--- a/components/LanguageDropdown.tsx
+++ b/components/LanguageDropdown.tsx
@@ -52,8 +52,8 @@ export default function LanguageDropdown({ isMobile = false, inMobileMenu = fals
         <CustomLink
           href={basePath}
           className={`px-3 py-2 rounded-md font-semibold border text-sm transition-colors ${
-            currentLocale === 'es' 
-              ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900' 
+            currentLocale === 'es'
+              ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
               : 'text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
           }`}
           onClick={() => {
@@ -62,13 +62,13 @@ export default function LanguageDropdown({ isMobile = false, inMobileMenu = fals
             }
           }}
         >
-          ES
+          <span className="mr-1">🇪🇸</span>ES
         </CustomLink>
         <CustomLink
           href={`/en${basePath}`}
           className={`px-3 py-2 rounded-md font-semibold border text-sm transition-colors ${
-            currentLocale === 'en' 
-              ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900' 
+            currentLocale === 'en'
+              ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
               : 'text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
           }`}
           onClick={() => {
@@ -77,7 +77,7 @@ export default function LanguageDropdown({ isMobile = false, inMobileMenu = fals
             }
           }}
         >
-          EN
+          <span className="mr-1">🇬🇧</span>EN
         </CustomLink>
       </div>
     )
@@ -93,6 +93,7 @@ export default function LanguageDropdown({ isMobile = false, inMobileMenu = fals
   return (
     <div className="relative" ref={dropdownRef}>
       <button onClick={() => setIsOpen(!isOpen)} className={buttonClasses} aria-label="Cambiar idioma">
+        <span className="mr-1">{currentLocale === 'en' ? '🇬🇧' : '🇪🇸'}</span>
         {currentLocale.toUpperCase()}
         <ChevronDown className={`w-4 h-4 ml-1 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>
@@ -109,7 +110,7 @@ export default function LanguageDropdown({ isMobile = false, inMobileMenu = fals
                 }
               }}
             >
-              ES
+              <span className="mr-1">🇪🇸</span>ES
             </CustomLink>
             <CustomLink
               href={`/en${basePath}`}
@@ -121,7 +122,7 @@ export default function LanguageDropdown({ isMobile = false, inMobileMenu = fals
                 }
               }}
             >
-              EN
+              <span className="mr-1">🇬🇧</span>EN
             </CustomLink>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- quita el componente de cambio de idioma del `Header`
- muestra `LanguageDropdown` al costado de `Breadcrumbs`

## Testing
- `yarn lint` *(fails: Error when performing the request ...)*

------
https://chatgpt.com/codex/tasks/task_e_6853e9bee5608321a3ba01acb1f5b5d1