### PR TITLE
Fix header offset in relato pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,9 +6,7 @@ import { Playfair_Display, Source_Serif_4 } from 'next/font/google'
 import { Analytics, AnalyticsConfig } from 'pliny/analytics'
 import { SearchProvider, SearchConfig } from 'pliny/search'
 import ConditionalHeader from '@/components/ConditionalHeader'
-import Breadcrumbs from '@/components/Breadcrumbs'
-import LanguageDropdown from '@/components/LanguageDropdown'
-import SectionContainer from '@/components/SectionContainer'
+import ConditionalTopBar from '@/components/ConditionalTopBar'
 import Footer from '@/components/Footer'
 import siteMetadata from '@/data/siteMetadata'
 import OrganizationSchema from '@/components/OrganizationSchema'
@@ -150,12 +148,7 @@ export default function RootLayout({
           <ThemeProviders>
             <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />
             <ConditionalHeader />
-            <SectionContainer>
-              <div className="flex items-center justify-between mt-4">
-                <Breadcrumbs />
-                <LanguageDropdown isMobile />
-              </div>
-            </SectionContainer>
+            <ConditionalTopBar />
             <SearchProvider searchConfig={siteMetadata.search as SearchConfig}>
               <main className="mb-auto font-serif">{children}</main>
             </SearchProvider>

--- a/components/ConditionalTopBar.tsx
+++ b/components/ConditionalTopBar.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import Breadcrumbs from './Breadcrumbs'
+import LanguageDropdown from './LanguageDropdown'
+import SectionContainer from './SectionContainer'
+
+export default function ConditionalTopBar() {
+  const pathname = usePathname()
+  if (pathname.startsWith('/relato/')) {
+    return null
+  }
+  return (
+    <SectionContainer>
+      <div className="flex items-center justify-between mt-4">
+        <Breadcrumbs />
+        <LanguageDropdown isMobile />
+      </div>
+    </SectionContainer>
+  )
+}


### PR DESCRIPTION
## Summary
- create `ConditionalTopBar` to avoid breadcrumbs margin on relato pages
- use this component from `layout.tsx`

## Testing
- `npx prettier -w components/ConditionalTopBar.tsx app/layout.tsx` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `yarn lint` *(fails to fetch yarnpkg-cli)*

------
https://chatgpt.com/codex/tasks/task_e_6854404f00808321b5cc25fcac0bdf28