### PR TITLE
Agrupar redes sociales en header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,6 +11,7 @@ import {
   ChevronDown,
   Facebook,
 } from 'lucide-react'
+import SocialDropdown from './SocialDropdown'
 import { useState } from 'react'
 import ThemeToggle from './ThemeToggle'
 import PublishDropdown from './PublishDropdown'
@@ -121,22 +122,7 @@ const Header = () => {
           </div>
           
           {/* Redes sociales */}
-          <div className="flex items-center gap-6">
-            {socialLinks.map((link) =>
-              link.href ? (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label={link.label}
-                  className="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100 transition-colors hidden sm:inline-flex"
-                >
-                  {link.icon}
-                </a>
-              ) : null
-            )}
-          </div>
+          <SocialDropdown />
           
           {/* Navegación y botón destacado */}
           <div className="flex items-center gap-2 ml-auto">

--- a/components/SocialDropdown.tsx
+++ b/components/SocialDropdown.tsx
@@ -56,7 +56,7 @@ export default function SocialDropdown() {
         <Share2 className="w-5 h-5 text-gray-700 dark:text-gray-300" />
       </button>
       {isOpen && (
-        <div className="absolute right-0 top-full mt-0 bg-white dark:bg-gray-950 border border-gray-200 dark:border-gray-800 rounded-md shadow-lg p-2 flex gap-4 z-50">
+        <div className="absolute right-0 top-full mt-0 bg-white dark:bg-gray-950 border border-gray-200 dark:border-gray-800 rounded-md shadow-lg w-40 py-1 z-50">
           {socialLinks.map((link) =>
             link.href ? (
               <a
@@ -64,10 +64,11 @@ export default function SocialDropdown() {
                 href={link.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label={link.label}
-                className="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100 transition-colors"
+                className="flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                onClick={() => setIsOpen(false)}
               >
                 {link.icon}
+                <span>{link.label}</span>
               </a>
             ) : null
           )}

--- a/components/SocialDropdown.tsx
+++ b/components/SocialDropdown.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import siteMetadata from '@/data/siteMetadata'
+import { Instagram, Facebook, Rss } from 'lucide-react'
+import { useState, useRef, useEffect } from 'react'
+
+const socialLinks = [
+  {
+    href: siteMetadata.instagram,
+    label: 'Instagram',
+    icon: <Instagram className="w-5 h-5" />,
+  },
+  {
+    href: siteMetadata.twitter,
+    label: 'X',
+    icon: (
+      <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current">
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+      </svg>
+    ),
+  },
+  {
+    href: siteMetadata.facebook,
+    label: 'Facebook',
+    icon: <Facebook className="w-5 h-5" />,
+  },
+]
+
+export default function SocialDropdown() {
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen])
+
+  return (
+    <div className="relative hidden sm:block" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        aria-label="Compartir"
+        className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
+      >
+        <Rss className="w-5 h-5 text-gray-700 dark:text-gray-300" />
+      </button>
+      {isOpen && (
+        <div className="absolute right-0 mt-1 bg-white dark:bg-gray-950 border border-gray-200 dark:border-gray-800 rounded-md shadow-lg p-2 flex gap-4 z-50">
+          {socialLinks.map((link) =>
+            link.href ? (
+              <a
+                key={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={link.label}
+                className="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100 transition-colors"
+              >
+                {link.icon}
+              </a>
+            ) : null
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/SocialDropdown.tsx
+++ b/components/SocialDropdown.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import siteMetadata from '@/data/siteMetadata'
-import { Instagram, Facebook, Rss } from 'lucide-react'
+import { Instagram, Facebook, Share2 } from 'lucide-react'
 import { useState, useRef, useEffect } from 'react'
 
 const socialLinks = [
@@ -53,10 +53,10 @@ export default function SocialDropdown() {
         aria-label="Compartir"
         className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800"
       >
-        <Rss className="w-5 h-5 text-gray-700 dark:text-gray-300" />
+        <Share2 className="w-5 h-5 text-gray-700 dark:text-gray-300" />
       </button>
       {isOpen && (
-        <div className="absolute right-0 mt-1 bg-white dark:bg-gray-950 border border-gray-200 dark:border-gray-800 rounded-md shadow-lg p-2 flex gap-4 z-50">
+        <div className="absolute right-0 top-full mt-0 bg-white dark:bg-gray-950 border border-gray-200 dark:border-gray-800 rounded-md shadow-lg p-2 flex gap-4 z-50">
           {socialLinks.map((link) =>
             link.href ? (
               <a


### PR DESCRIPTION
## Summary
- agregar componente `SocialDropdown`
- usar el nuevo dropdown en el header

## Testing
- `npx prettier components/SocialDropdown.tsx components/Header.tsx --write` *(falla: Cannot find package 'prettier-plugin-tailwindcss')*
- `yarn lint` *(falla: fetch failed por falta de internet)*

------
https://chatgpt.com/codex/tasks/task_e_6855d8378e348321affe46e2fcf8bc1d