### PR TITLE
Añade imágenes de autores en blanco y negro

### DIFF
--- a/app/autores/AutoresClient.tsx
+++ b/app/autores/AutoresClient.tsx
@@ -21,13 +21,13 @@ function AutorCard({ autor }: { autor: any }) {
             alt={autor.name}
             width={60}
             height={60}
-            className="rounded-full w-12 h-12 sm:w-16 sm:h-16"
+            className="rounded-full w-12 h-12 sm:w-16 sm:h-16 grayscale"
           />
         ) : (
           <AutoAvatar
             name={autor.name}
             size={60}
-            className="rounded-full bg-black text-white font-titles text-lg sm:text-xl flex items-center justify-center w-12 h-12 sm:w-16 sm:h-16"
+            className="rounded-full bg-black text-white font-titles text-lg sm:text-xl flex items-center justify-center w-12 h-12 sm:w-16 sm:h-16 grayscale"
           />
         )}
       </div>

--- a/layouts/AuthorLayout.tsx
+++ b/layouts/AuthorLayout.tsx
@@ -32,13 +32,13 @@ export default function AuthorLayout({ children, content }: Props) {
                 alt="avatar"
                 width={192}
                 height={192}
-                className="h-48 w-48 rounded-full"
+                className="h-48 w-48 rounded-full grayscale"
               />
             ) : (
               <AutoAvatar
                 name={name}
                 size={192}
-                className="h-48 w-48 rounded-full bg-black text-white font-titles text-5xl flex items-center justify-center"
+                className="h-48 w-48 rounded-full bg-black text-white font-titles text-5xl flex items-center justify-center grayscale"
               />
             )}
             <h3 className="pt-4 pb-2 text-2xl leading-8 font-bold tracking-tight">{name}</h3>


### PR DESCRIPTION
## Summary
- muestra avatars de autores en escala de grises en las páginas de /autores y /autor

## Testing
- `npx prettier -w app/autores/AutoresClient.tsx layouts/AuthorLayout.tsx`
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_686d6d818e9483218a82b7787e4c52b9